### PR TITLE
fix: status bar overlaps toolbar in AreaSettings

### DIFF
--- a/app/src/main/res/layout/activity_area_settings.xml
+++ b/app/src/main/res/layout/activity_area_settings.xml
@@ -5,6 +5,7 @@
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     tools:context=".AreaSettings">
 
     <androidx.appcompat.widget.Toolbar


### PR DESCRIPTION
上のステータスバーがツールバーを隠してしまう問題を解決